### PR TITLE
methods in ketchups controller

### DIFF
--- a/app/controllers/ketchups_controller.rb
+++ b/app/controllers/ketchups_controller.rb
@@ -1,2 +1,34 @@
 class KetchupsController < ApplicationController
+  before_action :set_trip, only: [:new, :create, :destroy]
+
+  def new
+    @ketchup = Ketchup.new
+  end
+
+  def create
+    @ketchup = Ketchup.new(ketchup_params)
+    @ketchup.trip = @trip
+    if @ketchup.save
+      redirect_to @trip, notice: 'Ketchup created.'
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    @ketchup = Ketchup.find(params[:id])
+    @ketchup.destroy
+    redirect_to trip_path(@ketchup.trip_id)
+  end
+
+  private
+
+  def set_trip
+    @trip = Trip.find(params[:id])
+  end
+
+  def ketchup_params
+    params.require(:ketchup).permit(:trip_id, :location, :message, :date, :status, :user_id)
+  end
+
 end

--- a/db/migrate/20200416090020_create_ketchups.rb
+++ b/db/migrate/20200416090020_create_ketchups.rb
@@ -3,7 +3,7 @@ class CreateKetchups < ActiveRecord::Migration[5.2]
     create_table :ketchups do |t|
       t.date :date
       t.time :start_time
-      t.integer :duratio
+      t.float :duratio
       t.string :location
       t.string :message
       t.string :status

--- a/db/migrate/20200416090020_create_ketchups.rb
+++ b/db/migrate/20200416090020_create_ketchups.rb
@@ -3,7 +3,7 @@ class CreateKetchups < ActiveRecord::Migration[5.2]
     create_table :ketchups do |t|
       t.date :date
       t.time :start_time
-      t.float :duratio
+      t.integer :duratio
       t.string :location
       t.string :message
       t.string :status

--- a/db/migrate/20200416123852_fix_duration_on_ketchups.rb
+++ b/db/migrate/20200416123852_fix_duration_on_ketchups.rb
@@ -1,0 +1,5 @@
+class FixDurationOnKetchups < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :ketchups, :duratio, :duration
+  end
+end


### PR DESCRIPTION
-methods in ketchups controller: new, create, destroy. 
-this commit also includes a migration to modify datatype of 'duration' on ketchups table from integer to float, and corrects typo in column name ('duratio' => 'duration'). will need to update controller to permit duration in ketchup params after migration is run