### PR TITLE
refactored notifications to rails syntax

### DIFF
--- a/app/assets/javascripts/notifications.js.coffee
+++ b/app/assets/javascripts/notifications.js.coffee
@@ -1,35 +1,35 @@
-class Notifications
-  constructor: ->
-    @notifications = $("[data-behavior='notifications']")
-    @setup() if @notifications.length > 0
+# class Notifications
+#   constructor: ->
+#     @notifications = $("[data-behavior='notifications']")
+#     @setup() if @notifications.length > 0
 
-  setup: ->
-    $("[data-behavior='notification-item']").on "click", @handleClick
-    $.ajax(
-      url: "/notifications.json"
-      dataType: "JSON"
-      method: "GET"
-      success: @handleSuccess
-    )
+#   setup: ->
+#     $("[data-behavior='notification-item']").on "click", @handleClick
+#     $.ajax(
+#       url: "/notifications.json"
+#       dataType: "JSON"
+#       method: "GET"
+#       success: @handleSuccess
+#     )
 
-  handleClick: (e) =>
-    $.ajax(
-      url: "/notifications/mark_as_read"
-      datatype: "JSON"
-      method: "POST"
-      success: ->
-        $("[data-behavior='unread-count']").text(0)
-    )
-  handleSuccess: (data) =>
-    console.log(data);
-    if data.length > 0
-      items = $.map data, (notification) ->
-        "<a class='dropdown-item' data-behavior='notification-item' data-id='#{notification.id}' href='#{notification.url}'>#{notification.actor} #{notification.action} #{notification.notifiable.type}</a>"
-      $("[data-behavior='unread-count']").text(items.length)
-      $("[data-behavior='notification-items']").html(items)
-    else
-      $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='#'>See All</a>")
-      # "<a class='dropdown-item' href='#{notification.all}'>SEE ALL</a>"
-      # $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='users/current_user/notifications'>See All</a>")
-jQuery ->
-  new Notifications
+#   handleClick: (e) =>
+#     $.ajax(
+#       url: "/notifications/mark_as_read"
+#       datatype: "JSON"
+#       method: "POST"
+#       success: ->
+#         $("[data-behavior='unread-count']").text(0)
+#     )
+#   handleSuccess: (data) =>
+#     console.log(data);
+#     if data.length > 0
+#       items = $.map data, (notification) ->
+#         "<a class='dropdown-item' data-behavior='notification-item' data-id='#{notification.id}' href='#{notification.url}'>#{notification.actor} #{notification.action} #{notification.notifiable.type}</a>"
+#       $("[data-behavior='unread-count']").text(items.length)
+#       $("[data-behavior='notification-items']").html(items)
+#     else
+#       $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='#'>See All</a>")
+#       # "<a class='dropdown-item' href='#{notification.all}'>SEE ALL</a>"
+#       # $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='users/current_user/notifications'>See All</a>")
+# jQuery ->
+#   new Notifications

--- a/app/assets/javascripts/notificationstest.js
+++ b/app/assets/javascripts/notificationstest.js
@@ -1,0 +1,113 @@
+// // class Notifications {
+// //   constructor(notifications)
+// //     // ("[data-behavior='notifications']")
+// //     // this.setup() if this.notifications.length > 0
+// //   }
+
+// const notifications = document.querySelector("[data-behavior='notification-items']")
+// console.log(notifications);
+
+// // GET request NEW
+// // const setup = fetch("/notifications.json")
+// //   .then(response => response.json())
+// //   .then((data) => {
+// //     console.log(data); // array of objects
+// //     console.log(data[0]); // individual object
+// //     console.log(data[0].actor); // accessing an element within an object
+// //     console.log(data[0].action);
+// //   });
+
+// document.getElementById("dropdownMenu1").addEventListener("click", handleSuccess);
+
+// function handleSuccess(data) {
+//   // items = data.map(notification => {
+//   notifications.insertAdjacentHTML("beforeend", "<a class='dropdown-item' data-behavior='notification-item' data-id='setup.id' href='#{notification.url}'>#{notification.actor} #{notification.action} #{notification.notifiable.type}</a>")
+//   console.log(data);
+//   console.log("Success!")
+//   }
+
+
+// //   .remove();
+
+
+// // POST request OLD
+
+// // const data = { name: "a name", email: "an@email.com" };
+
+// // $.ajax({
+// //   url: url,
+// //   type: "POST",
+// //   data: data,
+// //   success: function(data) {
+// //     console.log(data);
+// //   }
+// // });
+
+// // // POST request NEW
+// // const data = { name: "a name", email: "an@email.com" };
+// // fetch(url, {
+// //   method: 'POST',
+// //   headers: { "Content-Type": "application/json" },
+// //   body: JSON.stringify(data)})
+// //    .then(response => response.json())
+// //    .then((data) => {
+// //      console.log(data);
+// //    });
+
+// // // POST request OLD
+// //   handleClick: (e) =>
+// //     $.ajax(
+// //       url: "/notifications/mark_as_read"
+// //       datatype: "JSON"
+// //       method: "POST"
+// //       success: ->
+// //         $("[data-behavior='unread-count']").text(0)
+// //     )
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// //   setup: ->
+// //     $("[data-behavior='notifications-link']").on "click", @handleClick
+// //     $.ajax(
+// //       url: "/notifications.json"
+// //       dataType: "JSON"
+// //       method: "GET"
+// //       success: @handleSuccess
+// //     )
+
+
+
+
+
+
+
+
+
+
+// //   handleSuccess: (data) =>
+// //     console.log(data);
+// //     if data.length > 0
+// //       items = $.map data, (notification) ->
+// //         "<a class='dropdown-item' data-behavior='notification-item' data-id='#{notification.id}' href='#{notification.url}'>#{notification.actor} #{notification.action} #{notification.notifiable.type}</a>"
+// //       $("[data-behavior='unread-count']").text(items.length)
+// //       $("[data-behavior='notification-items']").html(items)
+// //     else
+// //       $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='#'>See All</a>")
+// //       # "<a class='dropdown-item' href='#{notification.all}'>SEE ALL</a>"
+// //       # $("[data-behavior='notification-items']").html("<a class='dropdown-item' href='users/current_user/notifications'>See All</a>")
+// // jQuery ->
+// //   new Notifications

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -10,6 +10,7 @@ class ChatsController < ApplicationController
     @messages = @chat.messages
     @my_messages = @chat.messages.where(["user_id = ?", current_user.id])
     @other_messages = @chat.messages.where(["user_id = ?", @chat.opposed_user(current_user).id])
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def create

--- a/app/controllers/ketchups_controller.rb
+++ b/app/controllers/ketchups_controller.rb
@@ -27,6 +27,7 @@ class KetchupsController < ApplicationController
     # else
     #   @duration = "#{@ketchup.duration}m"
     # end
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def create

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,11 +4,16 @@ class NotificationsController < ApplicationController
     @notifications = policy_scope(Notification).order(created_at: :desc)
   end
 
-  def mark_as_read
-    # @notifications = policy_scope(Notification).order(created_at: :desc)
-    notification = notification.find(data-id)
-    # check how to refer to data-id in this method
-    notification.update!(read_at: Time.zone.now)
-    # render json: {success: true}
+  def update
+    @notification = Notification.find(params[:id])
+    authorize @notification
+    if @notification.read_at.nil?
+      @notification.update!(read_at: Time.zone.now)
+    end
+    if @notification.notifiable_type == "Friendship" || @notification.notifiable_type == "FriendRequest"
+      redirect_to  user_friends_path(@notification.recipient)
+    elsif @notification.notifiable_type == "Ketchup"
+      redirect_to user_ketchups_path(@notification.recipient)
+   end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,5 +3,6 @@ class PagesController < ApplicationController
 
   def home
     @trip = Trip.new
+    @notifications = Notification.where(recipient: current_user).unread
   end
 end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -16,6 +16,7 @@ class TripsController < ApplicationController
     @end_month = @trip.end_date.strftime('%b')
     @end_day = @trip.end_date.strftime('%d')
     @chat = Chat.new
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,22 +3,27 @@ class UsersController < ApplicationController
 
   def trip
     @trips = Trip.where(["user_id = ? AND status= ?", @user.id, "confirmed"])
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def save
     @trips = Trip.where(["user_id = ? AND status= ?", @user.id, "saved"])
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def ketchup
     @pending_ketchups = Ketchup.where(["user_id = ? AND status= ?", @user.id, "pending"])
     @confirmed_ketchups = Ketchup.where(["user_id = ? AND status= ?", @user.id, "confirmed"])
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def notification
-    @notifications = Notification.where(recipient: @user).order("created_at DESC")
+    @my_notifications = Notification.where(recipient: @user).order("created_at DESC")
+    @notifications = Notification.where(recipient: current_user).unread
   end
 
   def friend
+    @notifications = Notification.where(recipient: current_user).unread
     @sent_requests = FriendRequest.where(["sender_id = ? AND status = ?", @user.id, "pending"])
     @received_requests = FriendRequest.where(["receiver_id = ? AND status = ?", @user.id, "pending"])
     @friendship = Friendship.new

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -5,7 +5,7 @@ class NotificationPolicy < ApplicationPolicy
     end
   end
 
-  def mark_as_read?
+  def update?
     user_is_recipient?
   end
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,11 +13,25 @@
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
         <!-- more nav items needed such as chat -->
-        <li class="nav-item btn-group" data-behavior="notifications" data-notifications='<%= render template: "notifications/index", formats: [:json] %>'>
-          <a class="dropdown-toggle nav-link" type="button" data-behavior="notifications-link" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="fas fa-bell"></i> <span data-behavior="unread-count"></span>
+        <li class="nav-item btn-group">
+          <a class="dropdown-toggle nav-link" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i class="fas fa-bell"></i>
+              <span class="unread-count">
+                <% if @notifications.length > 0 %>
+                  <%= @notifications.length %>
+                <% end %>
+              </span>
           </a>
-        <div class="dropdown-menu" aria-labelledby="dropdownMenu1" data-behavior="notification-items"></div>
+        <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <% if @notifications.present? %>
+          <% @notifications.each do |notification| %>
+          <%= link_to notification.actor.full_name + " " + notification.action + " " + notification.notifiable_type.to_s.underscore.humanize.downcase, notification_path(notification), method: :patch || :put, class: 'dropdown-item' %>
+          <% end %>
+          <%= link_to "See All", user_notifications_path(current_user), class: 'dropdown-item' %>
+          <% else %>
+          <%= link_to "See All", user_notifications_path(current_user), class: 'dropdown-item' %>
+          <% end %>
+        </div>
         </li>
         <li class="nav-item">
           <%= link_to "Friends", user_friends_path(current_user), class: "nav-link" %>

--- a/app/views/users/notification.html.erb
+++ b/app/views/users/notification.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
-  <% @notifications.each do |notification| %>
+  <% @my_notifications.each do |notification| %>
     <p><img class="avatar" src="https://kitt.lewagon.com/placeholder/users/<%= notification.actor.lewagon_username %>">
     <%= notification.actor.full_name %> (<%= notification.created_at %>)</p>
     <p><%= notification.action %>
-    <%= notification.notifiable_type.downcase %></p>
+    <%= notification.notifiable_type.to_s.underscore.humanize.downcase %></p>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     resources :friendships, only: [:create]
   end
 
-  resources :notifications, only: [:index, :create, :show] do
+  resources :notifications, only: [:index, :create, :show, :update] do
     collection do
       post :mark_as_read
     end


### PR DESCRIPTION
Turns out we don't need javascript at all to display clickable notifications in the navbar.

-update method in notifications controller marks notification as read (updates 'read_at' in db) & redirects to the corresponding page (friends list page for friend_requests, ketchups page for ketchups)
-navbar html & show all for notifications page updated to show details of each notification in a readable format
-@notifications added to home method in pages controller and all methods in users controller
-notification policy updated to change 'mark_as_read?' to 'update?' to match method name in notifications controller
-coffeescript file and notificationstest.js files are commented for future reference, but we can delete them down the line.
